### PR TITLE
upgrade to vertx 4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,12 +10,15 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '45 9 * * 5'
+    - cron: '36 16 * * 3'
   push:
-    branches: [ "main" ]
+    branches: [main]
+  # Run on PRs so Code Scanning receives Scorecard SARIF for PR commits (required by branch protection).
+  pull_request:
+    branches: [main]
 
 # Declare default permissions as read only.
-permissions:
+permissions: 
   contents: read
 
 jobs:
@@ -74,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.22.0
         with:
           sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+Reporting a Vulnerability
+We take the security of Hyphae seriously. We appreciate your efforts to responsibly disclose security vulnerabilities. If you believe you have found a security issue, please DO NOT open a public issue or pull request. Instead, please send a detailed email to:
+
+hyphae@lfenergy.org
+
+The email should include:
+
+A clear description of the vulnerability.
+Steps to reproduce the vulnerability.
+The affected version(s) of the project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,24 @@
-Reporting a Vulnerability
-We take the security of Hyphae seriously. We appreciate your efforts to responsibly disclose security vulnerabilities. If you believe you have found a security issue, please DO NOT open a public issue or pull request. Instead, please send a detailed email to:
+# Security policy
 
-hyphae@lfenergy.org
+## Supported versions
 
-The email should include:
+Security updates are applied to the latest release line maintained in this repository. Older major or minor lines may not receive backports unless explicitly documented in a release note.
 
-A clear description of the vulnerability.
-Steps to reproduce the vulnerability.
-The affected version(s) of the project.
+## Reporting a vulnerability
+
+Please report security issues privately so we can assess and address them before wider disclosure.
+
+Private vulnerability reporting is not currently supported.
+
+If you discover a security issue, please disclose it responsibly by contacting the maintainers via GitHub:
+- @FlawzyByte
+- @subhramit
+- @axmsoftware
+
+You may also submit a Pull Request with the remediation and request review from one of the maintainers above.
+
+Include enough detail to reproduce the issue (affected component or class, version or commit, and steps or proof of concept when possible).
+
+## Disclosure
+
+We ask that you allow a reasonable time for investigation and remediation before public disclosure, and coordinate with maintainers on timing when practical.

--- a/exe/cluster-mac.xml
+++ b/exe/cluster-mac.xml
@@ -1,158 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <properties>
-    <property name="hazelcast.mancenter.enabled">false</property>
-    <property name="hazelcast.memcache.enabled">false</property>
-    <property name="hazelcast.rest.enabled">false</property>
-    <property name="hazelcast.wait.seconds.before.join">5</property>
-  </properties>
+<hazelcast
+    xmlns="http://www.hazelcast.com/schema/config"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.hazelcast.com/schema/config
+        http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
 
-  <group>
-    <name>oss_cluster-3.0.0</name>
-    <password>oss_cluster-pass</password>
-  </group>
-  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
-  <network>
-    <port auto-increment="true" port-count="10000">5701</port>
-    <outbound-ports>
-      <!--
-      Allowed port range when connecting to other nodes.
-      0 or * means use system provided port.
-      -->
-      <ports>0</ports>
-    </outbound-ports>
-    <join>
-      <multicast enabled="true" loopbackModeEnabled="false">
-        <multicast-group>224.2.2.3</multicast-group>
-        <multicast-port>54327</multicast-port>
-      </multicast>
-      <tcp-ip enabled="false">
-        
-          <member>127.0.0.1</member>
-        
-      </tcp-ip>
-      <aws enabled="false">
-        <access-key>my-access-key</access-key>
-        <secret-key>my-secret-key</secret-key>
-        <!--optional, default is us-east-1 -->
-        <region>us-west-1</region>
-        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
-        <host-header>ec2.amazonaws.com</host-header>
-        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
-        <security-group-name>hazelcast-sg</security-group-name>
-        <tag-key>type</tag-key>
-        <tag-value>hz-nodes</tag-value>
-      </aws>
-    </join>
-    <interfaces enabled="true">
-      <interface>127.0.0.1</interface>
-    </interfaces>
-    <ssl enabled="false"/>
-    <socket-interceptor enabled="false"/>
-    <symmetric-encryption enabled="false">
-      <!--
-         encryption algorithm such as
-         DES/ECB/PKCS5Padding,
-         PBEWithMD5AndDES,
-         AES/CBC/PKCS5Padding,
-         Blowfish,
-         DESede
-      -->
-      <algorithm>PBEWithMD5AndDES</algorithm>
-      <!-- salt value to use when generating the secret key -->
-      <salt>thesalt</salt>
-      <!-- pass phrase to use when generating the secret key -->
-      <password>thepass</password>
-      <!-- iteration count to use when generating the secret key -->
-      <iteration-count>19</iteration-count>
-    </symmetric-encryption>
-  </network>
-  <partition-group enabled="false"/>
-  <executor-service name="default">
-    <pool-size>16</pool-size>
-    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
-    <queue-capacity>0</queue-capacity>
-  </executor-service>
+    <!-- Replaces the old <group> -->
+    <cluster-name>oss_cluster-3.0.0</cluster-name>
 
-  <multimap name="__vertx.subs">
+    <properties>
+        <property name="hazelcast.wait.seconds.before.join">5</property>
+    </properties>
 
-    <!--
-        Number of backups. If 1 is set as the backup-count for example,
-        then all entries of the map will be copied to another JVM for
-        fail-safety. 0 means no backup.
-    -->
-    <backup-count>6</backup-count>
-  </multimap>
+    <network>
+        <port auto-increment="true" port-count="10000">5701</port>
+        <outbound-ports>
+            <ports>0</ports>
+        </outbound-ports>
+        <join>
+            <!-- Same multicast configuration -->
+            <multicast enabled="true" loopbackModeEnabled="false">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
 
-  <map name="__vertx.haInfo">
+            <!-- Disabled -->
+            <tcp-ip enabled="false">
+                <member>127.0.0.1</member>
+            </tcp-ip>
 
-    <!--
-        Number of backups. If 1 is set as the backup-count for example,
-        then all entries of the map will be copied to another JVM for
-        fail-safety. 0 means no backup.
-    -->
-    <backup-count>1</backup-count>
-    <!--
-  Maximum number of seconds for each entry to stay in the map. Entries that are
-  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
-  will get automatically evicted from the map.
-  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
--->
-    <time-to-live-seconds>0</time-to-live-seconds>
-    <!--
-  Maximum number of seconds for each entry to stay idle in the map. Entries that are
-  idle(not touched) for more than <max-idle-seconds> will get
-  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
-  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
--->
-    <max-idle-seconds>0</max-idle-seconds>
-    <!--
-        Valid values are:
-        NONE (no eviction),
-        LRU (Least Recently Used),
-        LFU (Least Frequently Used).
-        NONE is the default.
-    -->
-    <eviction-policy>NONE</eviction-policy>
-    <!--
-        Maximum size of the map. When max size is reached,
-        map is evicted based on the policy defined.
-        Any integer between 0 and Integer.MAX_VALUE. 0 means
-        Integer.MAX_VALUE. Default is 0.
-    -->
-    <max-size policy="PER_NODE">0</max-size>
-    <!--
-        When max. size is reached, specified percentage of
-        the map will be evicted. Any integer between 0 and 100.
-        If 25 is set for example, 25% of the entries will
-        get evicted.
-    -->
-    <eviction-percentage>25</eviction-percentage>
-    <!--
-        While recovering from split-brain (network partitioning),
-        map entries in the small cluster will merge into the bigger cluster
-        based on the policy set here. When an entry merge into the
-        cluster, there might an existing entry with the same key already.
-        Values of these entries might be different for that same key.
-        Which value should be set for the key? Conflict is resolved by
-        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+            <!-- Prevent Hazelcast from enabling auto detection -->
+            <auto-detection enabled="false"/>
 
-        There are built-in merge policies such as
-        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
-        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
-        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
-        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
-    -->
-    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+        </join>
 
-  </map>
+        <interfaces enabled="true">
+            <interface>127.0.0.1</interface>
+        </interfaces>
 
-  <!-- Used internally in Vert.x to implement async locks -->
-  <semaphore name="__vertx.*">
-    <initial-permits>1</initial-permits>
-  </semaphore>
+        <ssl enabled="false"/>
+        <socket-interceptor enabled="false"/>
+
+    </network>
+
+    <partition-group enabled="false"/>
+
+    <executor-service name="default">
+        <pool-size>16</pool-size>
+        <queue-capacity>0</queue-capacity>
+    </executor-service>
+
+    <!-- Vert.x EventBus subscriptions -->
+    <multimap name="__vertx.subs">
+        <!--
+             6 is preserved from your original configuration,
+             although 1 or 2 is generally recommended.
+        -->
+        <backup-count>6</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <!-- HA deployment information -->
+    <map name="__vertx.haInfo">
+
+        <backup-count>1</backup-count>
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <max-idle-seconds>0</max-idle-seconds>
+        <eviction
+                eviction-policy="NONE"
+                max-size-policy="PER_NODE"
+                size="0"/>
+
+    </map>
+
+    <!-- New in Vert.x 4 -->
+    <map name="__vertx.nodeInfo">
+        <backup-count>1</backup-count>
+    </map>
+
+    <!-- Distributed locks used by Vert.x -->
+    <cp-subsystem>
+        <!-- Unsafe mode (same semantics as Hazelcast 3) -->
+        <cp-member-count>0</cp-member-count>
+        <semaphores>
+            <semaphore>
+                <name>__vertx.*</name>
+                <initial-permits>1</initial-permits>
+                <jdk-compatible>false</jdk-compatible>
+            </semaphore>
+        </semaphores>
+    </cp-subsystem>
 
 </hazelcast>

--- a/exe/cluster.xml
+++ b/exe/cluster.xml
@@ -1,158 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <properties>
-    <property name="hazelcast.mancenter.enabled">false</property>
-    <property name="hazelcast.memcache.enabled">false</property>
-    <property name="hazelcast.rest.enabled">false</property>
-    <property name="hazelcast.wait.seconds.before.join">5</property>
-  </properties>
+<hazelcast
+    xmlns="http://www.hazelcast.com/schema/config"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.hazelcast.com/schema/config
+        http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
 
-  <group>
-    <name>oss_cluster-3.0.0</name>
-    <password>oss_cluster-pass</password>
-  </group>
-  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
-  <network>
-    <port auto-increment="true" port-count="10000">5701</port>
-    <outbound-ports>
-      <!--
-      Allowed port range when connecting to other nodes.
-      0 or * means use system provided port.
-      -->
-      <ports>0</ports>
-    </outbound-ports>
-    <join>
-      <multicast enabled="true" loopbackModeEnabled="true">
-        <multicast-group>224.2.2.3</multicast-group>
-        <multicast-port>54327</multicast-port>
-      </multicast>
-      <tcp-ip enabled="false">
-        
-          <member>127.0.0.1</member>
-        
-      </tcp-ip>
-      <aws enabled="false">
-        <access-key>my-access-key</access-key>
-        <secret-key>my-secret-key</secret-key>
-        <!--optional, default is us-east-1 -->
-        <region>us-west-1</region>
-        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
-        <host-header>ec2.amazonaws.com</host-header>
-        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
-        <security-group-name>hazelcast-sg</security-group-name>
-        <tag-key>type</tag-key>
-        <tag-value>hz-nodes</tag-value>
-      </aws>
-    </join>
-    <interfaces enabled="true">
-      <interface>127.0.0.1</interface>
-    </interfaces>
-    <ssl enabled="false"/>
-    <socket-interceptor enabled="false"/>
-    <symmetric-encryption enabled="false">
-      <!--
-         encryption algorithm such as
-         DES/ECB/PKCS5Padding,
-         PBEWithMD5AndDES,
-         AES/CBC/PKCS5Padding,
-         Blowfish,
-         DESede
-      -->
-      <algorithm>PBEWithMD5AndDES</algorithm>
-      <!-- salt value to use when generating the secret key -->
-      <salt>thesalt</salt>
-      <!-- pass phrase to use when generating the secret key -->
-      <password>thepass</password>
-      <!-- iteration count to use when generating the secret key -->
-      <iteration-count>19</iteration-count>
-    </symmetric-encryption>
-  </network>
-  <partition-group enabled="false"/>
-  <executor-service name="default">
-    <pool-size>16</pool-size>
-    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
-    <queue-capacity>0</queue-capacity>
-  </executor-service>
+    <!-- Replaces the old <group> -->
+    <cluster-name>oss_cluster-3.0.0</cluster-name>
 
-  <multimap name="__vertx.subs">
+    <properties>
+        <property name="hazelcast.wait.seconds.before.join">5</property>
+    </properties>
 
-    <!--
-        Number of backups. If 1 is set as the backup-count for example,
-        then all entries of the map will be copied to another JVM for
-        fail-safety. 0 means no backup.
-    -->
-    <backup-count>6</backup-count>
-  </multimap>
+    <network>
+        <port auto-increment="true" port-count="10000">5701</port>
+        <outbound-ports>
+            <ports>0</ports>
+        </outbound-ports>
+        <join>
+            <!-- Same multicast configuration -->
+            <multicast enabled="true" loopbackModeEnabled="true">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
 
-  <map name="__vertx.haInfo">
+            <!-- Disabled -->
+            <tcp-ip enabled="false">
+                <member>127.0.0.1</member>
+            </tcp-ip>
 
-    <!--
-        Number of backups. If 1 is set as the backup-count for example,
-        then all entries of the map will be copied to another JVM for
-        fail-safety. 0 means no backup.
-    -->
-    <backup-count>1</backup-count>
-    <!--
-  Maximum number of seconds for each entry to stay in the map. Entries that are
-  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
-  will get automatically evicted from the map.
-  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
--->
-    <time-to-live-seconds>0</time-to-live-seconds>
-    <!--
-  Maximum number of seconds for each entry to stay idle in the map. Entries that are
-  idle(not touched) for more than <max-idle-seconds> will get
-  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
-  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
--->
-    <max-idle-seconds>0</max-idle-seconds>
-    <!--
-        Valid values are:
-        NONE (no eviction),
-        LRU (Least Recently Used),
-        LFU (Least Frequently Used).
-        NONE is the default.
-    -->
-    <eviction-policy>NONE</eviction-policy>
-    <!--
-        Maximum size of the map. When max size is reached,
-        map is evicted based on the policy defined.
-        Any integer between 0 and Integer.MAX_VALUE. 0 means
-        Integer.MAX_VALUE. Default is 0.
-    -->
-    <max-size policy="PER_NODE">0</max-size>
-    <!--
-        When max. size is reached, specified percentage of
-        the map will be evicted. Any integer between 0 and 100.
-        If 25 is set for example, 25% of the entries will
-        get evicted.
-    -->
-    <eviction-percentage>25</eviction-percentage>
-    <!--
-        While recovering from split-brain (network partitioning),
-        map entries in the small cluster will merge into the bigger cluster
-        based on the policy set here. When an entry merge into the
-        cluster, there might an existing entry with the same key already.
-        Values of these entries might be different for that same key.
-        Which value should be set for the key? Conflict is resolved by
-        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+            <!-- Prevent Hazelcast from enabling auto detection -->
+            <auto-detection enabled="false"/>
 
-        There are built-in merge policies such as
-        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
-        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
-        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
-        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
-    -->
-    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+        </join>
 
-  </map>
+        <interfaces enabled="true">
+            <interface>127.0.0.1</interface>
+        </interfaces>
 
-  <!-- Used internally in Vert.x to implement async locks -->
-  <semaphore name="__vertx.*">
-    <initial-permits>1</initial-permits>
-  </semaphore>
+        <ssl enabled="false"/>
+        <socket-interceptor enabled="false"/>
+
+    </network>
+
+    <partition-group enabled="false"/>
+
+    <executor-service name="default">
+        <pool-size>16</pool-size>
+        <queue-capacity>0</queue-capacity>
+    </executor-service>
+
+    <!-- Vert.x EventBus subscriptions -->
+    <multimap name="__vertx.subs">
+        <!--
+             6 is preserved from your original configuration,
+             although 1 or 2 is generally recommended.
+        -->
+        <backup-count>6</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <!-- HA deployment information -->
+    <map name="__vertx.haInfo">
+
+        <backup-count>1</backup-count>
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <max-idle-seconds>0</max-idle-seconds>
+        <eviction
+                eviction-policy="NONE"
+                max-size-policy="PER_NODE"
+                size="0"/>
+
+    </map>
+
+    <!-- New in Vert.x 4 -->
+    <map name="__vertx.nodeInfo">
+        <backup-count>1</backup-count>
+    </map>
+
+    <!-- Distributed locks used by Vert.x -->
+    <cp-subsystem>
+        <!-- Unsafe mode (same semantics as Hazelcast 3) -->
+        <cp-member-count>0</cp-member-count>
+        <semaphores>
+            <semaphore>
+                <name>__vertx.*</name>
+                <initial-permits>1</initial-permits>
+                <jdk-compatible>false</jdk-compatible>
+            </semaphore>
+        </semaphores>
+    </cp-subsystem>
 
 </hazelcast>

--- a/exe/start.sh
+++ b/exe/start.sh
@@ -4,6 +4,6 @@ CLUSTER_XML=cluster.xml
 if [ "$(uname)" = 'Darwin' ] ; then
 	CLUSTER_XML=cluster-mac.xml
 fi
-java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo -Djava.util.logging.config.file=./logging.properties -Dvertx.hazelcast.config=./$CLUSTER_XML -jar ../target/apis-ccc-3.0.0-fat.jar -conf ./config.json -cluster -cluster-host 127.0.0.1
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo -Djava.util.logging.config.file=./logging.properties -Dvertx.hazelcast.config=./$CLUSTER_XML -jar ../target/apis-ccc-4.5.10-fat.jar -conf ./config.json -cluster -cluster-host 127.0.0.1
 
 echo '... done'

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <groupId>jp.co.sony.csl.dcoes.apis</groupId>
@@ -71,10 +72,6 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.1</version>
-          <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -154,7 +151,6 @@
         <version>3.3.1</version>
         <configuration>
           <author>true</author>
-          <source>1.8</source>
           <show>private</show>
           <encoding>UTF-8</encoding>
           <charset>UTF-8</charset>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <!-- We specify the Maven compiler plugin as we need to set it to Java 1.8 -->
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.1</version>

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
@@ -2,7 +2,7 @@ package jp.co.sony.csl.dcoes.apis.tools.ccc;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
@@ -211,7 +211,7 @@ public class DealReporting extends AbstractVerticle {
 			return;
 		}
 		if (log.isInfoEnabled()) log.info("reporting deals ...");
-		vertx.eventBus().<JsonArray>send(ServiceAddress.Mediator.deals(), null, rep -> {
+		vertx.eventBus().<JsonArray>request(ServiceAddress.Mediator.deals(), null, rep -> {
 			if (rep.succeeded()) {
 				JsonArray result = rep.result().body();
 				if (result != null) {

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
@@ -166,7 +166,7 @@ public class DealReporting extends AbstractVerticle {
 						if (resReport.succeeded()) {
 							req.reply("ok");
 						} else {
-							log.error("Communication failed with ServiceCenter ; {}", resReport.cause());
+							log.error("Communication failed with ServiceCenter", resReport.cause());
 							req.fail(-1, resReport.cause().getMessage());
 						}
 					});
@@ -243,7 +243,7 @@ public class DealReporting extends AbstractVerticle {
 							if (resReport.succeeded()) {
 								// nop
 							} else {
-								log.error("Communication failed with ServiceCenter ; {}", resReport.cause());
+								log.error("Communication failed with ServiceCenter", resReport.cause());
 							}
 							setDealReportingTimer_();
 						});
@@ -255,7 +255,7 @@ public class DealReporting extends AbstractVerticle {
 					setDealReportingTimer_();
 				}
 			} else {
-				log.error("Communication failed on EventBus ; {}", rep.cause());
+				log.error("Communication failed on EventBus", rep.cause());
 				setDealReportingTimer_();
 			}
 		});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
@@ -6,8 +6,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.co.sony.csl.dcoes.apis.common.Deal;
 import jp.co.sony.csl.dcoes.apis.common.ServiceAddress;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.JsonObjectUtil;
@@ -104,7 +104,7 @@ public class DealReporting extends AbstractVerticle {
 		startDealReportingService_(resDealReporting -> {
 			if (resDealReporting.succeeded()) {
 				if (enabled_) dealReportingTimerHandler_(0L);
-				if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
+				if (log.isTraceEnabled()) log.trace("started : {}", deploymentID());
 				startPromise.complete();
 			} else {
 				startPromise.fail(resDealReporting.cause());
@@ -122,7 +122,7 @@ public class DealReporting extends AbstractVerticle {
 	 */
 	@Override public void stop() throws Exception {
 		stopped_ = true;
-		if (log.isTraceEnabled()) log.trace("stopped : " + deploymentID());
+		if (log.isTraceEnabled()) log.trace("stopped : {}", deploymentID());
 	}
 
 	////
@@ -160,13 +160,13 @@ public class DealReporting extends AbstractVerticle {
 					// Adds reporting time (actual UNIX time)
 					// 通知時間 ( 実時間の UNIX 時間 ) を追加する
 					long now = System.currentTimeMillis() / 1000;
-					if (log.isDebugEnabled()) log.debug("reportTime : " + now);
+					if (log.isDebugEnabled()) log.debug("reportTime : {}", now);
 					deal.put("reportTime", now);
 					impl_.report(deal, resReport -> {
 						if (resReport.succeeded()) {
 							req.reply("ok");
 						} else {
-							log.error("Communication failed with ServiceCenter ; " + resReport.cause());
+							log.error("Communication failed with ServiceCenter ; {}", resReport.cause());
 							req.fail(-1, resReport.cause().getMessage());
 						}
 					});
@@ -215,7 +215,7 @@ public class DealReporting extends AbstractVerticle {
 			if (rep.succeeded()) {
 				JsonArray result = rep.result().body();
 				if (result != null) {
-					if (log.isInfoEnabled()) log.info("size of result : " + result.size());
+					if (log.isInfoEnabled()) log.info("size of result : {}", result.size());
 					if (!result.isEmpty()) {
 						// Discards DEAL information that does not need to be recorded
 						// 記録する必要のない DEAL 情報を捨てる
@@ -226,11 +226,11 @@ public class DealReporting extends AbstractVerticle {
 							}
 						}
 						result = filtered;
-						if (log.isInfoEnabled()) log.info("size of filtered result : " + result.size());
+						if (log.isInfoEnabled()) log.info("size of filtered result : {}", result.size());
 					}
 					if (!result.isEmpty()) {
 						long now = System.currentTimeMillis() / 1000;
-						if (log.isDebugEnabled()) log.debug("reportTime : " + now);
+						if (log.isDebugEnabled()) log.debug("reportTime : {}", now);
 						for (Object aDeal : result) {
 							// Adds community ID and cluster ID
 							// コミュニティ ID とクラスタ ID を追加する
@@ -243,7 +243,7 @@ public class DealReporting extends AbstractVerticle {
 							if (resReport.succeeded()) {
 								// nop
 							} else {
-								log.error("Communication failed with ServiceCenter ; " + resReport.cause());
+								log.error("Communication failed with ServiceCenter ; {}", resReport.cause());
 							}
 							setDealReportingTimer_();
 						});
@@ -255,7 +255,7 @@ public class DealReporting extends AbstractVerticle {
 					setDealReportingTimer_();
 				}
 			} else {
-				log.error("Communication failed on EventBus ; " + rep.cause());
+				log.error("Communication failed on EventBus ; {}", rep.cause());
 				setDealReportingTimer_();
 			}
 		});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/DealReporting.java
@@ -62,7 +62,7 @@ public class DealReporting extends AbstractVerticle {
 	 * Prepares the object to be implemented.
 	 * Starts {@link io.vertx.core.eventbus.EventBus} service.
 	 * Starts the timer.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 * 起動時に呼び出される.
 	 * CONFIG から設定を取得し初期化する.
@@ -71,11 +71,11 @@ public class DealReporting extends AbstractVerticle {
 	 * 実装オブジェクトを用意する.
 	 * {@link io.vertx.core.eventbus.EventBus} サービスを起動する.
 	 * タイマを起動する.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 */
 
-	@Override public void start(Future<Void> startFuture) throws Exception {
+	@Override public void start(Promise<Void> startPromise) throws Exception {
 		enabled_ = VertxConfig.config.getBoolean(Boolean.TRUE, "dealReporting", "enabled");
 		if (enabled_) {
 			if (log.isInfoEnabled()) log.info("dealReporting enabled");
@@ -90,11 +90,11 @@ public class DealReporting extends AbstractVerticle {
 					break;
 				}
 				if (impl_ == null) {
-					startFuture.fail("unknown CONFIG.dealReporting.type value : " + type);
+					startPromise.fail("unknown CONFIG.dealReporting.type value : " + type);
 					return;
 				}
 			} catch (Exception e) {
-				startFuture.fail(e);
+				startPromise.fail(e);
 				return;
 			}
 		} else {
@@ -105,9 +105,9 @@ public class DealReporting extends AbstractVerticle {
 			if (resDealReporting.succeeded()) {
 				if (enabled_) dealReportingTimerHandler_(0L);
 				if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
-				startFuture.complete();
+				startPromise.complete();
 			} else {
-				startFuture.fail(resDealReporting.cause());
+				startPromise.fail(resDealReporting.cause());
 			}
 		});
 	}

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
@@ -35,17 +35,17 @@ public class PolicyAcquisition extends AbstractVerticle {
 	 * - {@code CONFIG.policyAcquisition.enabled}
 	 * Prepares the object to be implemented.
 	 * Starts {@link io.vertx.core.eventbus.EventBus} service.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
  	 * 起動時に呼び出される.
 	 * CONFIG から設定を取得し初期化する.
 	 * - {@code CONFIG.policyAcquisition.enabled}
 	 * 実装オブジェクトを用意する.
 	 * {@link io.vertx.core.eventbus.EventBus} サービスを起動する.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 */
-	@Override public void start(Future<Void> startFuture) throws Exception {
+	@Override public void start(Promise<Void> startPromise) throws Exception {
 		enabled_ = VertxConfig.config.getBoolean(Boolean.TRUE, "policyAcquisition", "enabled");
 		if (enabled_) {
 			if (log.isInfoEnabled()) log.info("policyAcquisition enabled");
@@ -57,9 +57,9 @@ public class PolicyAcquisition extends AbstractVerticle {
 		startPolicyService_(resPolicy -> {
 			if (resPolicy.succeeded()) {
 				if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
-				startFuture.complete();
+				startPromise.complete();
 			} else {
-				startFuture.fail(resPolicy.cause());
+				startPromise.fail(resPolicy.cause());
 			}
 		});
 	}

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
@@ -115,7 +115,7 @@ public class PolicyAcquisition extends AbstractVerticle {
 						JsonObject result = resAcquire.result();
 						req.reply(result);
 					} else {
-						log.error("Communication failed with ServiceCenter ; {}", resAcquire.cause());
+						log.error("Communication failed with ServiceCenter", resAcquire.cause());
 						req.fail(-1, resAcquire.cause().getMessage());
 					}
 				});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
@@ -2,7 +2,7 @@ package jp.co.sony.csl.dcoes.apis.tools.ccc;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/PolicyAcquisition.java
@@ -5,8 +5,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.co.sony.csl.dcoes.apis.common.ServiceAddress;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.VertxConfig;
 import jp.co.sony.csl.dcoes.apis.tools.ccc.impl.http_post.HttpPostPolicyAcquisitionImpl;
@@ -56,7 +56,7 @@ public class PolicyAcquisition extends AbstractVerticle {
 
 		startPolicyService_(resPolicy -> {
 			if (resPolicy.succeeded()) {
-				if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
+				if (log.isTraceEnabled()) log.trace("started : {}", deploymentID());
 				startPromise.complete();
 			} else {
 				startPromise.fail(resPolicy.cause());
@@ -71,7 +71,7 @@ public class PolicyAcquisition extends AbstractVerticle {
 	 * @throws Exception {@inheritDoc}
 	 */
 	@Override public void stop() throws Exception {
-		if (log.isTraceEnabled()) log.trace("stopped : " + deploymentID());
+		if (log.isTraceEnabled()) log.trace("stopped : {}", deploymentID());
 	}
 
 	////
@@ -115,7 +115,7 @@ public class PolicyAcquisition extends AbstractVerticle {
 						JsonObject result = resAcquire.result();
 						req.reply(result);
 					} else {
-						log.error("Communication failed with ServiceCenter ; " + resAcquire.cause());
+						log.error("Communication failed with ServiceCenter ; {}", resAcquire.cause());
 						req.fail(-1, resAcquire.cause().getMessage());
 					}
 				});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
@@ -5,8 +5,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.co.sony.csl.dcoes.apis.common.ServiceAddress;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.VertxConfig;
 import jp.co.sony.csl.dcoes.apis.tools.ccc.impl.http_post.HttpPostScenarioAcquisitionImpl;
@@ -57,7 +57,7 @@ public class ScenarioAcquisition extends AbstractVerticle {
 
 		startScenarioService_(resScenario -> {
 			if (resScenario.succeeded()) {
-				if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
+				if (log.isTraceEnabled()) log.trace("started : {}", deploymentID());
 				startPromise.complete();
 			} else {
 				startPromise.fail(resScenario.cause());
@@ -72,7 +72,7 @@ public class ScenarioAcquisition extends AbstractVerticle {
 	 * @throws Exception {@inheritDoc}
 	 */
 	@Override public void stop() throws Exception {
-		if (log.isTraceEnabled()) log.trace("stopped : " + deploymentID());
+		if (log.isTraceEnabled()) log.trace("stopped : {}", deploymentID());
 	}
 
 	////
@@ -116,7 +116,7 @@ public class ScenarioAcquisition extends AbstractVerticle {
 						JsonObject result = resAcquire.result();
 						req.reply(result);
 					} else {
-						log.error("Communication failed with ServiceCenter ; " + resAcquire.cause());
+						log.error("Communication failed with ServiceCenter ; {}", resAcquire.cause());
 						req.fail(-1, resAcquire.cause().getMessage());
 					}
 				});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
@@ -116,7 +116,7 @@ public class ScenarioAcquisition extends AbstractVerticle {
 						JsonObject result = resAcquire.result();
 						req.reply(result);
 					} else {
-						log.error("Communication failed with ServiceCenter ; {}", resAcquire.cause());
+						log.error("Communication failed with ServiceCenter", resAcquire.cause());
 						req.fail(-1, resAcquire.cause().getMessage());
 					}
 				});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
@@ -36,17 +36,17 @@ public class ScenarioAcquisition extends AbstractVerticle {
 	 * - {@code CONFIG.scenarioAcquisition.enabled}
 	 * Prepares the object to be implemented.
 	 * Starts {@link io.vertx.core.eventbus.EventBus} service. 
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 * 起動時に呼び出される.
 	 * CONFIG から設定を取得し初期化する.
 	 * - {@code CONFIG.scenarioAcquisition.enabled}
 	 * 実装オブジェクトを用意する.
 	 * {@link io.vertx.core.eventbus.EventBus} サービスを起動する.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 */
-	@Override public void start(Future<Void> startFuture) throws Exception {
+	@Override public void start(Promise<Void> startPromise) throws Exception {
 		enabled_ = VertxConfig.config.getBoolean(Boolean.TRUE, "scenarioAcquisition", "enabled");
 		if (enabled_) {
 			if (log.isInfoEnabled()) log.info("scenarioAcquisition enabled");
@@ -58,9 +58,9 @@ public class ScenarioAcquisition extends AbstractVerticle {
 		startScenarioService_(resScenario -> {
 			if (resScenario.succeeded()) {
 				if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
-				startFuture.complete();
+				startPromise.complete();
 			} else {
-				startFuture.fail(resScenario.cause());
+				startPromise.fail(resScenario.cause());
 			}
 		});
 	}

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/ScenarioAcquisition.java
@@ -2,7 +2,7 @@ package jp.co.sony.csl.dcoes.apis.tools.ccc;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
@@ -5,8 +5,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.co.sony.csl.dcoes.apis.common.ServiceAddress;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.JsonObjectUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.VertxConfig;
@@ -96,7 +96,7 @@ public class UnitDataReporting extends AbstractVerticle {
 		}
 
 		if (enabled_) unitDataReportingTimerHandler_(0L);
-		if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
+		if (log.isTraceEnabled()) log.trace("started : {}", deploymentID());
 		startPromise.complete();
 	}
 
@@ -110,7 +110,7 @@ public class UnitDataReporting extends AbstractVerticle {
 	 */
 	@Override public void stop() throws Exception {
 		stopped_ = true;
-		if (log.isTraceEnabled()) log.trace("stopped : " + deploymentID());
+		if (log.isTraceEnabled()) log.trace("stopped : {}", deploymentID());
 	}
 
 	////
@@ -149,7 +149,7 @@ public class UnitDataReporting extends AbstractVerticle {
 			if (rep.succeeded()) {
 				JsonObject result = rep.result().body();
 				if (result != null) {
-					if (log.isInfoEnabled()) log.info("size of unit data : " + result.size());
+					if (log.isInfoEnabled()) log.info("size of unit data : {}", result.size());
 					if (!result.isEmpty()) {
 						// Ensures that the element is a JsonObject
 						// 要素が JsonObject であることを保証する
@@ -159,17 +159,17 @@ public class UnitDataReporting extends AbstractVerticle {
 							if (aVal instanceof JsonObject) {
 								filtered.put(aKey, aVal);
 							} else {
-								if (log.isWarnEnabled()) log.warn("invalid unitData item : " + aVal);
+								if (log.isWarnEnabled()) log.warn("invalid unitData item : {}", aVal);
 							}
 						}
 						result = filtered;
-						if (log.isInfoEnabled()) log.info("size of filtered unit data : " + result.size());
+						if (log.isInfoEnabled()) log.info("size of filtered unit data : {}", result.size());
 					}
 					if (!result.isEmpty()) {
 						// Adds data unit ID
 						// データセット ID を追加する
 						long id = System.currentTimeMillis();
-						if (log.isDebugEnabled()) log.debug("datasetId : " + id);
+						if (log.isDebugEnabled()) log.debug("datasetId : {}", id);
 						for (String aKey : result.fieldNames()) {
 							JsonObject aVal = result.getJsonObject(aKey);
 							aVal.put("datasetId", id);
@@ -178,7 +178,7 @@ public class UnitDataReporting extends AbstractVerticle {
 							if (resReport.succeeded()) {
 								// nop
 							} else {
-								log.error("Communication failed with ServiceCenter ; " + resReport.cause());
+								log.error("Communication failed with ServiceCenter ; {}", resReport.cause());
 							}
 							setUnitDataReportingTimer_();
 						});
@@ -191,7 +191,7 @@ public class UnitDataReporting extends AbstractVerticle {
 					setUnitDataReportingTimer_();
 				}
 			} else {
-				log.error("Communication failed on EventBus ; " + rep.cause());
+				log.error("Communication failed on EventBus ; {}", rep.cause());
 				setUnitDataReportingTimer_();
 			}
 		});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
@@ -178,7 +178,7 @@ public class UnitDataReporting extends AbstractVerticle {
 							if (resReport.succeeded()) {
 								// nop
 							} else {
-								log.error("Communication failed with ServiceCenter ; {}", resReport.cause());
+								log.error("Communication failed with ServiceCenter", resReport.cause());
 							}
 							setUnitDataReportingTimer_();
 						});
@@ -191,7 +191,7 @@ public class UnitDataReporting extends AbstractVerticle {
 					setUnitDataReportingTimer_();
 				}
 			} else {
-				log.error("Communication failed on EventBus ; {}", rep.cause());
+				log.error("Communication failed on EventBus", rep.cause());
 				setUnitDataReportingTimer_();
 			}
 		});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
@@ -145,7 +145,7 @@ public class UnitDataReporting extends AbstractVerticle {
 			return;
 		}
 		if (log.isInfoEnabled()) log.info("reporting unit data ...");
-		vertx.eventBus().<JsonObject>send(ServiceAddress.GridMaster.unitDatas(), null, rep -> {
+		vertx.eventBus().<JsonObject>request(ServiceAddress.GridMaster.unitDatas(), null, rep -> {
 			if (rep.succeeded()) {
 				JsonObject result = rep.result().body();
 				if (result != null) {

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
@@ -2,7 +2,7 @@ package jp.co.sony.csl.dcoes.apis.tools.ccc;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/UnitDataReporting.java
@@ -59,17 +59,17 @@ public class UnitDataReporting extends AbstractVerticle {
 	 * - {@code CONFIG.unitDataReporting.type}
 	 * Prepares the object to be implemented.
 	 * Starts the timer.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 * CONFIG から設定を取得し初期化する.
 	 * - {@code CONFIG.unitDataReporting.enabled}
 	 * - {@code CONFIG.unitDataReporting.type}
 	 * 実装オブジェクトを用意する.
 	 * タイマを起動する.
-	 * @param startFuture {@inheritDoc}
+	 * @param startPromise {@inheritDoc}
 	 * @throws Exception {@inheritDoc}
 	 */
-	@Override public void start(Future<Void> startFuture) throws Exception {
+	@Override public void start(Promise<Void> startPromise) throws Exception {
 		enabled_ = VertxConfig.config.getBoolean(Boolean.TRUE, "unitDataReporting", "enabled");
 		if (enabled_) {
 			if (log.isInfoEnabled()) log.info("unitDataReporting enabled");
@@ -84,11 +84,11 @@ public class UnitDataReporting extends AbstractVerticle {
 					break;
 				}
 				if (impl_ == null) {
-					startFuture.fail("unknown CONFIG.unitDataReporting.type value : " + type);
+					startPromise.fail("unknown CONFIG.unitDataReporting.type value : " + type);
 					return;
 				}
 			} catch (Exception e) {
-				startFuture.fail(e);
+				startPromise.fail(e);
 				return;
 			}
 		} else {
@@ -97,7 +97,7 @@ public class UnitDataReporting extends AbstractVerticle {
 
 		if (enabled_) unitDataReportingTimerHandler_(0L);
 		if (log.isTraceEnabled()) log.trace("started : " + deploymentID());
-		startFuture.complete();
+		startPromise.complete();
 	}
 
 	/**

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostDealReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostDealReportingImpl.java
@@ -145,38 +145,7 @@ public class HttpPostDealReportingImpl implements DealReporting.Impl {
 				}
 			});
 		}
-		/**
- 		* NOTE: The method {@code HttpClient.post(String, Handler<HttpClientResponse>)} used below is deprecated
- 		* in newer versions of Vert.x. However, this project currently targets Vert.x 3.5.3, where this method is
- 		* the supported and appropriate way to perform simple HTTP POST requests.
- 		*
- 		* It is acceptable to continue using this method for now because:
- 		* - The newer, preferred API ({@code request(HttpMethod, ...)} or {@code WebClient}) was introduced in later
- 		*   Vert.x versions (3.6+ for request-based API, 3.5.4+ for WebClient).
- 		* - Upgrading Vert.x is not feasible at this time due to compatibility constraints across the project.
- 		*
- 		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
- 		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
- 		*/
-		// @SuppressWarnings("deprecation")
-		// private void post_(Handler<AsyncResult<Void>> completionHandler) {
-		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "dealReporting", "requestTimeoutMsec");
-		// 	client_.post(uri_, resPost -> {
-		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-		// 		if (resPost.statusCode() == 200) {
-		// 			completionHandler.handle(Future.succeededFuture());
-		// 		} else {
-		// 			resPost.bodyHandler(error -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-		// 			}).exceptionHandler(t -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-		// 			});
-		// 		}
-		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-		// 		completionHandler.handle(Future.failedFuture(t));
-		// 	}).putHeader("content-type", "application/json").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		// }
-		
+
 		private void post_(Handler<AsyncResult<Void>> completionHandler) {
             Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "dealReporting", "requestTimeoutMsec");
             

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostDealReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostDealReportingImpl.java
@@ -9,8 +9,8 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.ZonedDateTime;
 
@@ -68,10 +68,10 @@ public class HttpPostDealReportingImpl implements DealReporting.Impl {
 		Integer port = (isSsl) ? VertxConfig.config.getInteger(443, "dealReporting", "port") : VertxConfig.config.getInteger(80, "dealReporting", "port");
 		Boolean sslTrustAll = VertxConfig.config.getBoolean(false, "dealReporting", "sslTrustAll");
 		uri_ = VertxConfig.config.getString("dealReporting", "uri");
-		if (log.isInfoEnabled()) log.info("host : " + host);
-		if (log.isInfoEnabled()) log.info("port : " + port);
-		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : " + sslTrustAll);
-		if (log.isInfoEnabled()) log.info("uri : " + uri_);
+		if (log.isInfoEnabled()) log.info("host : {}", host);
+		if (log.isInfoEnabled()) log.info("port : {}", port);
+		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : {}", sslTrustAll);
+		if (log.isInfoEnabled()) log.info("uri : {}", uri_);
 		client_ = vertx_.createHttpClient(new HttpClientOptions().setDefaultHost(host).setDefaultPort(port).setSsl(isSsl).setTrustAll(sslTrustAll));
 	}
 
@@ -89,7 +89,7 @@ public class HttpPostDealReportingImpl implements DealReporting.Impl {
 			convertDateTimeField_((JsonObject) aDeal);
 		}
 		Buffer body = Buffer.buffer(deals.encode());
-		if (log.isDebugEnabled()) log.debug("body : " + body);
+		if (log.isDebugEnabled()) log.debug("body : {}", body);
 		new Poster_(body).execute_(completionHandler);
 	}
 
@@ -141,7 +141,7 @@ public class HttpPostDealReportingImpl implements DealReporting.Impl {
 					completed_ = true;
 					completionHandler.handle(r);
 				} else {
-					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : " + r);
+					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : {}", r);
 				}
 			});
 		}
@@ -208,8 +208,8 @@ public class HttpPostDealReportingImpl implements DealReporting.Impl {
 
                     io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
 
-                    if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-                    
+                    if (log.isDebugEnabled()) log.debug("status : {}", resPost.statusCode());
+
                     if (resPost.statusCode() == 200) {
                         completionHandler.handle(Future.succeededFuture());
                     } else {

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostDealReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostDealReportingImpl.java
@@ -158,24 +158,71 @@ public class HttpPostDealReportingImpl implements DealReporting.Impl {
  		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
  		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
  		*/
-		@SuppressWarnings("deprecation")
+		// @SuppressWarnings("deprecation")
+		// private void post_(Handler<AsyncResult<Void>> completionHandler) {
+		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "dealReporting", "requestTimeoutMsec");
+		// 	client_.post(uri_, resPost -> {
+		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+		// 		if (resPost.statusCode() == 200) {
+		// 			completionHandler.handle(Future.succeededFuture());
+		// 		} else {
+		// 			resPost.bodyHandler(error -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+		// 			}).exceptionHandler(t -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+		// 			});
+		// 		}
+		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
+		// 		completionHandler.handle(Future.failedFuture(t));
+		// 	}).putHeader("content-type", "application/json").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
+		// }
+		
 		private void post_(Handler<AsyncResult<Void>> completionHandler) {
-			Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "dealReporting", "requestTimeoutMsec");
-			client_.post(uri_, resPost -> {
-				if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-				if (resPost.statusCode() == 200) {
-					completionHandler.handle(Future.succeededFuture());
-				} else {
-					resPost.bodyHandler(error -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-					}).exceptionHandler(t -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-					});
-				}
-			}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-				completionHandler.handle(Future.failedFuture(t));
-			}).putHeader("content-type", "application/json").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		}
+            Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "dealReporting", "requestTimeoutMsec");
+            
+            // 1. Create the request future asynchronously
+            client_.request(io.vertx.core.http.HttpMethod.POST, uri_).onComplete(reqResult -> {
+                if (reqResult.failed()) {
+                    completionHandler.handle(Future.failedFuture(reqResult.cause()));
+                    return;
+                }
+
+                io.vertx.core.http.HttpClientRequest req = reqResult.result();
+
+                // Configure request options
+                req.setTimeout(requestTimeoutMsec);
+                req.putHeader("content-type", "application/json");
+                req.putHeader("content-length", String.valueOf(body_.length()));
+
+                // 2. Set up the exception handler for connection/network issues
+                req.exceptionHandler(t -> {
+                    completionHandler.handle(Future.failedFuture(t));
+                });
+
+                // 3. Send the request with the payload and listen to the response
+                req.send(body_, resPostResult -> {
+                    if (resPostResult.failed()) {
+                        completionHandler.handle(Future.failedFuture(resPostResult.cause()));
+                        return;
+                    }
+
+                    io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
+
+                    if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+                    
+                    if (resPost.statusCode() == 200) {
+                        completionHandler.handle(Future.succeededFuture());
+                    } else {
+                        // Handle reading the error response body
+                        resPost.bodyHandler(error -> {
+                            completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+                        }).exceptionHandler(t -> {
+                            completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+                        });
+                    }
+                });
+            });
+        }
 	}
 
 }

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostPolicyAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostPolicyAcquisitionImpl.java
@@ -8,8 +8,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.co.sony.csl.dcoes.apis.common.util.StringUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.VertxConfig;
 import jp.co.sony.csl.dcoes.apis.tools.ccc.PolicyAcquisition;
@@ -61,10 +61,10 @@ public class HttpPostPolicyAcquisitionImpl implements PolicyAcquisition.Impl {
 		Integer port = (isSsl) ? VertxConfig.config.getInteger(443, "policyAcquisition", "port") : VertxConfig.config.getInteger(80, "policyAcquisition", "port");
 		Boolean sslTrustAll = VertxConfig.config.getBoolean(false, "policyAcquisition", "sslTrustAll");
 		uri_ = VertxConfig.config.getString("policyAcquisition", "uri");
-		if (log.isInfoEnabled()) log.info("host : " + host);
-		if (log.isInfoEnabled()) log.info("port : " + port);
-		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : " + sslTrustAll);
-		if (log.isInfoEnabled()) log.info("uri : " + uri_);
+		if (log.isInfoEnabled()) log.info("host : {}", host);
+		if (log.isInfoEnabled()) log.info("port : {}", port);
+		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : {}", sslTrustAll);
+		if (log.isInfoEnabled()) log.info("uri : {}", uri_);
 		client_ = vertx_.createHttpClient(new HttpClientOptions().setDefaultHost(host).setDefaultPort(port).setSsl(isSsl).setTrustAll(sslTrustAll));
 	}
 
@@ -79,7 +79,7 @@ public class HttpPostPolicyAcquisitionImpl implements PolicyAcquisition.Impl {
 		body.appendString("&clusterId=").appendString(StringUtil.urlEncode(VertxConfig.clusterId()));
 		body.appendString("&unitId=").appendString(StringUtil.urlEncode(unitId));
 		body.appendString("&isMD5Password=true");
-		if (log.isDebugEnabled()) log.debug("body : " + body);
+		if (log.isDebugEnabled()) log.debug("body : {}", body);
 		new Poster_(body).execute_(completionHandler);
 	}
 
@@ -105,7 +105,7 @@ public class HttpPostPolicyAcquisitionImpl implements PolicyAcquisition.Impl {
 					completed_ = true;
 					completionHandler.handle(r);
 				} else {
-					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : " + r);
+					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : {}", r);
 				}
 			});
 		}
@@ -184,15 +184,15 @@ public class HttpPostPolicyAcquisitionImpl implements PolicyAcquisition.Impl {
 
                     io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
 
-                    if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-                    
+                    if (log.isDebugEnabled()) log.debug("status : {}", resPost.statusCode());
+
                     if (resPost.statusCode() == 200) {
                         resPost.bodyHandler(buffer -> {
                             String resp = String.valueOf(buffer);
                             if (0 < resp.length()) {
                                 try {
                                     JsonObject result = new JsonObject(resp);
-                                    if (log.isDebugEnabled()) log.debug("result : " + result);
+                                    if (log.isDebugEnabled()) log.debug("result : {}", result);
                                     completionHandler.handle(Future.succeededFuture(result));
                                 } catch (Exception e) {
                                     // Safeguard for JSON parsing issues

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostPolicyAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostPolicyAcquisitionImpl.java
@@ -109,49 +109,6 @@ public class HttpPostPolicyAcquisitionImpl implements PolicyAcquisition.Impl {
 				}
 			});
 		}
-		/**
- 		* NOTE: The method {@code HttpClient.post(String, Handler<HttpClientResponse>)} used below is deprecated
- 		* in newer versions of Vert.x. However, this project currently targets Vert.x 3.5.3, where this method is
- 		* the supported and appropriate way to perform simple HTTP POST requests.
- 		*
- 		* It is acceptable to continue using this method for now because:
- 		* - The newer, preferred API ({@code request(HttpMethod, ...)} or {@code WebClient}) was introduced in later
- 		*   Vert.x versions (3.6+ for request-based API, 3.5.4+ for WebClient).
- 		* - Upgrading Vert.x is not feasible at this time due to compatibility constraints across the project.
- 		*
- 		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
- 		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
- 		*/
-		// @SuppressWarnings("deprecation")
-		// private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
-		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "policyAcquisition", "requestTimeoutMsec");
-		// 	client_.post(uri_, resPost -> {
-		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-		// 		if (resPost.statusCode() == 200) {
-		// 			resPost.bodyHandler(buffer -> {
-		// 				String resp = String.valueOf(buffer);
-		// 				if (0 < resp.length()) {
-		// 					JsonObject result = new JsonObject(resp);
-		// 					if (log.isDebugEnabled()) log.debug("result : " + result);
-		// 					completionHandler.handle(Future.succeededFuture(result));
-		// 				} else {
-		// 					if (log.isDebugEnabled()) log.debug("result : null");
-		// 					completionHandler.handle(Future.succeededFuture());
-		// 				}
-		// 			}).exceptionHandler(t -> {
-		// 				completionHandler.handle(Future.failedFuture(t));
-		// 			});
-		// 		} else {
-		// 			resPost.bodyHandler(error -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-		// 			}).exceptionHandler(t -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-		// 			});
-		// 		}
-		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-		// 		completionHandler.handle(Future.failedFuture(t));
-		// 	}).putHeader("content-type", "application/x-www-form-urlencoded").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		// }
 
 		private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
             Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "policyAcquisition", "requestTimeoutMsec");

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostPolicyAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostPolicyAcquisitionImpl.java
@@ -122,36 +122,99 @@ public class HttpPostPolicyAcquisitionImpl implements PolicyAcquisition.Impl {
  		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
  		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
  		*/
-		@SuppressWarnings("deprecation")
+		// @SuppressWarnings("deprecation")
+		// private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
+		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "policyAcquisition", "requestTimeoutMsec");
+		// 	client_.post(uri_, resPost -> {
+		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+		// 		if (resPost.statusCode() == 200) {
+		// 			resPost.bodyHandler(buffer -> {
+		// 				String resp = String.valueOf(buffer);
+		// 				if (0 < resp.length()) {
+		// 					JsonObject result = new JsonObject(resp);
+		// 					if (log.isDebugEnabled()) log.debug("result : " + result);
+		// 					completionHandler.handle(Future.succeededFuture(result));
+		// 				} else {
+		// 					if (log.isDebugEnabled()) log.debug("result : null");
+		// 					completionHandler.handle(Future.succeededFuture());
+		// 				}
+		// 			}).exceptionHandler(t -> {
+		// 				completionHandler.handle(Future.failedFuture(t));
+		// 			});
+		// 		} else {
+		// 			resPost.bodyHandler(error -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+		// 			}).exceptionHandler(t -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+		// 			});
+		// 		}
+		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
+		// 		completionHandler.handle(Future.failedFuture(t));
+		// 	}).putHeader("content-type", "application/x-www-form-urlencoded").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
+		// }
+
 		private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
-			Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "policyAcquisition", "requestTimeoutMsec");
-			client_.post(uri_, resPost -> {
-				if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-				if (resPost.statusCode() == 200) {
-					resPost.bodyHandler(buffer -> {
-						String resp = String.valueOf(buffer);
-						if (0 < resp.length()) {
-							JsonObject result = new JsonObject(resp);
-							if (log.isDebugEnabled()) log.debug("result : " + result);
-							completionHandler.handle(Future.succeededFuture(result));
-						} else {
-							if (log.isDebugEnabled()) log.debug("result : null");
-							completionHandler.handle(Future.succeededFuture());
-						}
-					}).exceptionHandler(t -> {
-						completionHandler.handle(Future.failedFuture(t));
-					});
-				} else {
-					resPost.bodyHandler(error -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-					}).exceptionHandler(t -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-					});
-				}
-			}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-				completionHandler.handle(Future.failedFuture(t));
-			}).putHeader("content-type", "application/x-www-form-urlencoded").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		}
+            Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "policyAcquisition", "requestTimeoutMsec");
+            
+            // 1. Initiate the asynchronous request
+            client_.request(io.vertx.core.http.HttpMethod.POST, uri_).onComplete(reqResult -> {
+                if (reqResult.failed()) {
+                    completionHandler.handle(Future.failedFuture(reqResult.cause()));
+                    return;
+                }
+
+                io.vertx.core.http.HttpClientRequest req = reqResult.result();
+
+                // Configure request properties
+                req.setTimeout(requestTimeoutMsec);
+                req.putHeader("content-type", "application/x-www-form-urlencoded");
+                req.putHeader("content-length", String.valueOf(body_.length()));
+
+                // Handle network/connection exceptions
+                req.exceptionHandler(t -> {
+                    completionHandler.handle(Future.failedFuture(t));
+                });
+
+                // 2. Send the body and capture the response
+                req.send(body_, resPostResult -> {
+                    if (resPostResult.failed()) {
+                        completionHandler.handle(Future.failedFuture(resPostResult.cause()));
+                        return;
+                    }
+
+                    io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
+
+                    if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+                    
+                    if (resPost.statusCode() == 200) {
+                        resPost.bodyHandler(buffer -> {
+                            String resp = String.valueOf(buffer);
+                            if (0 < resp.length()) {
+                                try {
+                                    JsonObject result = new JsonObject(resp);
+                                    if (log.isDebugEnabled()) log.debug("result : " + result);
+                                    completionHandler.handle(Future.succeededFuture(result));
+                                } catch (Exception e) {
+                                    // Safeguard for JSON parsing issues
+                                    completionHandler.handle(Future.failedFuture(e));
+                                }
+                            } else {
+                                if (log.isDebugEnabled()) log.debug("result : null");
+                                completionHandler.handle(Future.succeededFuture());
+                            }
+                        }).exceptionHandler(t -> {
+                            completionHandler.handle(Future.failedFuture(t));
+                        });
+                    } else {
+                        resPost.bodyHandler(error -> {
+                            completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+                        }).exceptionHandler(t -> {
+                            completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+                        });
+                    }
+                });
+            });
+        }
 	}
 
 }

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
@@ -8,8 +8,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.co.sony.csl.dcoes.apis.common.util.StringUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.VertxConfig;
 import jp.co.sony.csl.dcoes.apis.tools.ccc.ScenarioAcquisition;
@@ -64,10 +64,10 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
 		Integer port = (isSsl) ? VertxConfig.config.getInteger(443, "scenarioAcquisition", "port") : VertxConfig.config.getInteger(80, "scenarioAcquisition", "port");
 		Boolean sslTrustAll = VertxConfig.config.getBoolean(false, "scenarioAcquisition", "sslTrustAll");
 		uri_ = VertxConfig.config.getString("scenarioAcquisition", "uri");
-		if (log.isInfoEnabled()) log.info("host : " + host);
-		if (log.isInfoEnabled()) log.info("port : " + port);
-		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : " + sslTrustAll);
-		if (log.isInfoEnabled()) log.info("uri : " + uri_);
+		if (log.isInfoEnabled()) log.info("host : {}", host);
+		if (log.isInfoEnabled()) log.info("port : {}", port);
+		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : {}", sslTrustAll);
+		if (log.isInfoEnabled()) log.info("uri : {}", uri_);
 		client_ = vertx_.createHttpClient(new HttpClientOptions().setDefaultHost(host).setDefaultPort(port).setSsl(isSsl).setTrustAll(sslTrustAll));
 	}
 
@@ -82,7 +82,7 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
 		body.appendString("&clusterId=").appendString(StringUtil.urlEncode(VertxConfig.clusterId()));
 		body.appendString("&unitId=").appendString(StringUtil.urlEncode(unitId));
 		body.appendString("&isMD5Password=true");
-		if (log.isDebugEnabled()) log.debug("body : " + body);
+		if (log.isDebugEnabled()) log.debug("body : {}", body);
 		new Poster_(body).execute_(completionHandler);
 	}
 
@@ -108,7 +108,7 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
 					completed_ = true;
 					completionHandler.handle(r);
 				} else {
-					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : " + r);
+					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : {}", r);
 				}
 			});
 		}
@@ -187,14 +187,14 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
 
 					io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
 
-					if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+					if (log.isDebugEnabled()) log.debug("status : {}", resPost.statusCode());
 					
 					if (resPost.statusCode() == 200) {
 						resPost.bodyHandler(buffer -> {
 							String resp = String.valueOf(buffer);
 							if (0 < resp.length()) {
 								JsonObject result = new JsonObject(resp);
-								if (log.isDebugEnabled()) log.debug("result : " + result);
+								if (log.isDebugEnabled()) log.debug("result : {}", result);
 								completionHandler.handle(Future.succeededFuture(result));
 							} else {
 								if (log.isDebugEnabled()) log.debug("result : null");

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
@@ -112,49 +112,6 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
 				}
 			});
 		}
-		/**
- 		* NOTE: The method {@code HttpClient.post(String, Handler<HttpClientResponse>)} used below is deprecated
- 		* in newer versions of Vert.x. However, this project currently targets Vert.x 3.5.3, where this method is
- 		* the supported and appropriate way to perform simple HTTP POST requests.
- 		*
- 		* It is acceptable to continue using this method for now because:
-		* - The newer, preferred API ({@code request(HttpMethod, ...)} or {@code WebClient}) was introduced in later
- 		*   Vert.x versions (3.6+ for request-based API, 3.5.4+ for WebClient).
- 		* - Upgrading Vert.x is not feasible at this time due to compatibility constraints across the project.
- 		*
- 		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
- 		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
- 		*/
-		// @SuppressWarnings("deprecation")
-		// private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
-		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "scenarioAcquisition", "requestTimeoutMsec");
-		// 	client_.post(uri_, resPost -> {
-		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-		// 		if (resPost.statusCode() == 200) {
-		// 			resPost.bodyHandler(buffer -> {
-		// 				String resp = String.valueOf(buffer);
-		// 				if (0 < resp.length()) {
-		// 					JsonObject result = new JsonObject(resp);
-		// 					if (log.isDebugEnabled()) log.debug("result : " + result);
-		// 					completionHandler.handle(Future.succeededFuture(result));
-		// 				} else {
-		// 					if (log.isDebugEnabled()) log.debug("result : null");
-		// 					completionHandler.handle(Future.succeededFuture());
-		// 				}
-		// 			}).exceptionHandler(t -> {
-		// 				completionHandler.handle(Future.failedFuture(t));
-		// 			});
-		// 		} else {
-		// 			resPost.bodyHandler(error -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-		// 			}).exceptionHandler(t -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-		// 			});
-		// 		}
-		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-		// 		completionHandler.handle(Future.failedFuture(t));
-		// 	}).putHeader("content-type", "application/x-www-form-urlencoded").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		// }
 
 		private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
 			Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "scenarioAcquisition", "requestTimeoutMsec");

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
@@ -125,35 +125,93 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
  		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
  		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
  		*/
-		@SuppressWarnings("deprecation")
+		// @SuppressWarnings("deprecation")
+		// private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
+		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "scenarioAcquisition", "requestTimeoutMsec");
+		// 	client_.post(uri_, resPost -> {
+		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+		// 		if (resPost.statusCode() == 200) {
+		// 			resPost.bodyHandler(buffer -> {
+		// 				String resp = String.valueOf(buffer);
+		// 				if (0 < resp.length()) {
+		// 					JsonObject result = new JsonObject(resp);
+		// 					if (log.isDebugEnabled()) log.debug("result : " + result);
+		// 					completionHandler.handle(Future.succeededFuture(result));
+		// 				} else {
+		// 					if (log.isDebugEnabled()) log.debug("result : null");
+		// 					completionHandler.handle(Future.succeededFuture());
+		// 				}
+		// 			}).exceptionHandler(t -> {
+		// 				completionHandler.handle(Future.failedFuture(t));
+		// 			});
+		// 		} else {
+		// 			resPost.bodyHandler(error -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+		// 			}).exceptionHandler(t -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+		// 			});
+		// 		}
+		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
+		// 		completionHandler.handle(Future.failedFuture(t));
+		// 	}).putHeader("content-type", "application/x-www-form-urlencoded").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
+		// }
+
 		private void post_(Handler<AsyncResult<JsonObject>> completionHandler) {
 			Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "scenarioAcquisition", "requestTimeoutMsec");
-			client_.post(uri_, resPost -> {
-				if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-				if (resPost.statusCode() == 200) {
-					resPost.bodyHandler(buffer -> {
-						String resp = String.valueOf(buffer);
-						if (0 < resp.length()) {
-							JsonObject result = new JsonObject(resp);
-							if (log.isDebugEnabled()) log.debug("result : " + result);
-							completionHandler.handle(Future.succeededFuture(result));
-						} else {
-							if (log.isDebugEnabled()) log.debug("result : null");
-							completionHandler.handle(Future.succeededFuture());
-						}
-					}).exceptionHandler(t -> {
-						completionHandler.handle(Future.failedFuture(t));
-					});
-				} else {
-					resPost.bodyHandler(error -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-					}).exceptionHandler(t -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-					});
+			
+			// 1. Create the request future asynchronously
+			client_.request(io.vertx.core.http.HttpMethod.POST, uri_).onComplete(reqResult -> {
+				if (reqResult.failed()) {
+					completionHandler.handle(Future.failedFuture(reqResult.cause()));
+					return;
 				}
-			}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-				completionHandler.handle(Future.failedFuture(t));
-			}).putHeader("content-type", "application/x-www-form-urlencoded").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
+
+				io.vertx.core.http.HttpClientRequest req = reqResult.result();
+
+				// Configure request headers and timeout
+				req.setTimeout(requestTimeoutMsec);
+				req.putHeader("content-type", "application/x-www-form-urlencoded");
+				req.putHeader("content-length", String.valueOf(body_.length()));
+
+				// 2. Handle connection or network errors
+				req.exceptionHandler(t -> {
+					completionHandler.handle(Future.failedFuture(t));
+				});
+
+				// 3. Send the body buffer and process the response callback
+				req.send(body_, resPostResult -> {
+					if (resPostResult.failed()) {
+						completionHandler.handle(Future.failedFuture(resPostResult.cause()));
+						return;
+					}
+
+					io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
+
+					if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+					
+					if (resPost.statusCode() == 200) {
+						resPost.bodyHandler(buffer -> {
+							String resp = String.valueOf(buffer);
+							if (0 < resp.length()) {
+								JsonObject result = new JsonObject(resp);
+								if (log.isDebugEnabled()) log.debug("result : " + result);
+								completionHandler.handle(Future.succeededFuture(result));
+							} else {
+								if (log.isDebugEnabled()) log.debug("result : null");
+								completionHandler.handle(Future.succeededFuture());
+							}
+						}).exceptionHandler(t -> {
+							completionHandler.handle(Future.failedFuture(t));
+						});
+					} else {
+						resPost.bodyHandler(error -> {
+							completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+						}).exceptionHandler(t -> {
+							completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+						});
+					}
+				});
+			});
 		}
 	}
 

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostScenarioAcquisitionImpl.java
@@ -150,9 +150,13 @@ public class HttpPostScenarioAcquisitionImpl implements ScenarioAcquisition.Impl
 						resPost.bodyHandler(buffer -> {
 							String resp = String.valueOf(buffer);
 							if (0 < resp.length()) {
-								JsonObject result = new JsonObject(resp);
-								if (log.isDebugEnabled()) log.debug("result : {}", result);
-								completionHandler.handle(Future.succeededFuture(result));
+								try {
+									JsonObject result = new JsonObject(resp);
+									if (log.isDebugEnabled()) log.debug("result : {}", result);
+									completionHandler.handle(Future.succeededFuture(result));
+								} catch (Exception e) {
+									completionHandler.handle(Future.failedFuture(e));
+								}
 							} else {
 								if (log.isDebugEnabled()) log.debug("result : null");
 								completionHandler.handle(Future.succeededFuture());

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostUnitDataReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostUnitDataReportingImpl.java
@@ -9,8 +9,8 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.ZonedDateTime;
 
@@ -68,10 +68,10 @@ public class HttpPostUnitDataReportingImpl implements UnitDataReporting.Impl {
 		Integer port = (isSsl) ? VertxConfig.config.getInteger(443, "unitDataReporting", "port") : VertxConfig.config.getInteger(80, "unitDataReporting", "port");
 		Boolean sslTrustAll = VertxConfig.config.getBoolean(false, "unitDataReporting", "sslTrustAll");
 		uri_ = VertxConfig.config.getString("unitDataReporting", "uri");
-		if (log.isInfoEnabled()) log.info("host : " + host);
-		if (log.isInfoEnabled()) log.info("port : " + port);
-		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : " + sslTrustAll);
-		if (log.isInfoEnabled()) log.info("uri : " + uri_);
+		if (log.isInfoEnabled()) log.info("host : {}", host);
+		if (log.isInfoEnabled()) log.info("port : {}", port);
+		if (isSsl) if (log.isInfoEnabled()) log.info("sslTrustAll : {}", sslTrustAll);
+		if (log.isInfoEnabled()) log.info("uri : {}", uri_);
 		client_ = vertx_.createHttpClient(new HttpClientOptions().setDefaultHost(host).setDefaultPort(port).setSsl(isSsl).setTrustAll(sslTrustAll));
 	}
 
@@ -82,7 +82,7 @@ public class HttpPostUnitDataReportingImpl implements UnitDataReporting.Impl {
 		convertDateTimeField_(unitData);
 		JsonArray unitDataAsArray = toArray_(unitData);
 		Buffer body = Buffer.buffer(unitDataAsArray.encode());
-		if (log.isDebugEnabled()) log.debug("body : " + body);
+		if (log.isDebugEnabled()) log.debug("body : {}", body);
 		new Poster_(body).execute_(completionHandler);
 	}
 
@@ -135,7 +135,7 @@ public class HttpPostUnitDataReportingImpl implements UnitDataReporting.Impl {
 					completed_ = true;
 					completionHandler.handle(r);
 				} else {
-					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : " + r);
+					if (log.isWarnEnabled()) log.warn("post_() result returned more than once : {}", r);
 				}
 			});
 		}
@@ -202,7 +202,7 @@ public class HttpPostUnitDataReportingImpl implements UnitDataReporting.Impl {
 
                     io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
 
-                    if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+                    if (log.isDebugEnabled()) log.debug("status : {}", resPost.statusCode());
                     
                     if (resPost.statusCode() == 200) {
                         completionHandler.handle(Future.succeededFuture());

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostUnitDataReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostUnitDataReportingImpl.java
@@ -152,24 +152,71 @@ public class HttpPostUnitDataReportingImpl implements UnitDataReporting.Impl {
  		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
  		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
  		*/
-		@SuppressWarnings("deprecation")
+		// @SuppressWarnings("deprecation")
+		// private void post_(Handler<AsyncResult<Void>> completionHandler) {
+		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "unitDataReporting", "requestTimeoutMsec");
+		// 	client_.post(uri_, resPost -> {
+		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+		// 		if (resPost.statusCode() == 200) {
+		// 			completionHandler.handle(Future.succeededFuture());
+		// 		} else {
+		// 			resPost.bodyHandler(error -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+		// 			}).exceptionHandler(t -> {
+		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+		// 			});
+		// 		}
+		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
+		// 		completionHandler.handle(Future.failedFuture(t));
+		// 	}).putHeader("content-type", "application/json").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
+		// }
+
 		private void post_(Handler<AsyncResult<Void>> completionHandler) {
-			Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "unitDataReporting", "requestTimeoutMsec");
-			client_.post(uri_, resPost -> {
-				if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-				if (resPost.statusCode() == 200) {
-					completionHandler.handle(Future.succeededFuture());
-				} else {
-					resPost.bodyHandler(error -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-					}).exceptionHandler(t -> {
-						completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-					});
-				}
-			}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-				completionHandler.handle(Future.failedFuture(t));
-			}).putHeader("content-type", "application/json").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		}
+            Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "unitDataReporting", "requestTimeoutMsec");
+            
+            // 1. Create the request future asynchronously
+            client_.request(io.vertx.core.http.HttpMethod.POST, uri_).onComplete(reqResult -> {
+                if (reqResult.failed()) {
+                    completionHandler.handle(Future.failedFuture(reqResult.cause()));
+                    return;
+                }
+
+                io.vertx.core.http.HttpClientRequest req = reqResult.result();
+
+                // Configure request settings and headers
+                req.setTimeout(requestTimeoutMsec);
+                req.putHeader("content-type", "application/json");
+                req.putHeader("content-length", String.valueOf(body_.length()));
+
+                // 2. Setup exception handler for network/connection issues
+                req.exceptionHandler(t -> {
+                    completionHandler.handle(Future.failedFuture(t));
+                });
+
+                // 3. Send the request payload and process the response
+                req.send(body_, resPostResult -> {
+                    if (resPostResult.failed()) {
+                        completionHandler.handle(Future.failedFuture(resPostResult.cause()));
+                        return;
+                    }
+
+                    io.vertx.core.http.HttpClientResponse resPost = resPostResult.result();
+
+                    if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
+                    
+                    if (resPost.statusCode() == 200) {
+                        completionHandler.handle(Future.succeededFuture());
+                    } else {
+                        // Handle reading the error response body
+                        resPost.bodyHandler(error -> {
+                            completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
+                        }).exceptionHandler(t -> {
+                            completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
+                        });
+                    }
+                });
+            });
+        }
 	}
 
 }

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostUnitDataReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/http_post/HttpPostUnitDataReportingImpl.java
@@ -139,37 +139,6 @@ public class HttpPostUnitDataReportingImpl implements UnitDataReporting.Impl {
 				}
 			});
 		}
-		/**
- 		* NOTE: The method {@code HttpClient.post(String, Handler<HttpClientResponse>)} used below is deprecated
- 		* in newer versions of Vert.x. However, this project currently targets Vert.x 3.5.3, where this method is
- 		* the supported and appropriate way to perform simple HTTP POST requests.
- 		*
- 		* It is acceptable to continue using this method for now because:
- 		* - The newer, preferred API ({@code request(HttpMethod, ...)} or {@code WebClient}) was introduced in later
- 		*   Vert.x versions (3.6+ for request-based API, 3.5.4+ for WebClient).
- 		* - Upgrading Vert.x is not feasible at this time due to compatibility constraints across the project.
- 		*
- 		* Refactoring to the modern API should be planned once the project is upgraded to a newer Vert.x version
- 		* (3.6+ or 4.x) to ensure forward compatibility and eliminate deprecation warnings.
- 		*/
-		// @SuppressWarnings("deprecation")
-		// private void post_(Handler<AsyncResult<Void>> completionHandler) {
-		// 	Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "unitDataReporting", "requestTimeoutMsec");
-		// 	client_.post(uri_, resPost -> {
-		// 		if (log.isDebugEnabled()) log.debug("status : " + resPost.statusCode());
-		// 		if (resPost.statusCode() == 200) {
-		// 			completionHandler.handle(Future.succeededFuture());
-		// 		} else {
-		// 			resPost.bodyHandler(error -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + error));
-		// 			}).exceptionHandler(t -> {
-		// 				completionHandler.handle(Future.failedFuture("http post failed : " + resPost.statusCode() + " : " + resPost.statusMessage() + " : " + t));
-		// 			});
-		// 		}
-		// 	}).setTimeout(requestTimeoutMsec).exceptionHandler(t -> {
-		// 		completionHandler.handle(Future.failedFuture(t));
-		// 	}).putHeader("content-type", "application/json").putHeader("content-length", String.valueOf(body_.length())).write(body_).end();
-		// }
 
 		private void post_(Handler<AsyncResult<Void>> completionHandler) {
             Long requestTimeoutMsec = VertxConfig.config.getLong(DEFAULT_REQUEST_TIMEOUT_MSEC, "unitDataReporting", "requestTimeoutMsec");

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBDealReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBDealReportingImpl.java
@@ -8,8 +8,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.mongo.UpdateOptions;
@@ -82,12 +82,12 @@ public class MongoDBDealReportingImpl implements DealReporting.Impl {
 		if (ssl) config.put("trustAll", sslTrustAll);
 		client_ = MongoClient.createShared(vertx, config);
 		collection_ = VertxConfig.config.getString("dealReporting", "collection");
-		if (log.isInfoEnabled()) log.info("host : " + host);
-		if (log.isInfoEnabled()) log.info("port : " + port);
-		if (log.isInfoEnabled()) log.info("ssl : " + ssl);
-		if (ssl) if (log.isInfoEnabled()) log.info("sslTrustAll : " + sslTrustAll);
-		if (log.isInfoEnabled()) log.info("database : " + database);
-		if (log.isInfoEnabled()) log.info("collection : " + collection_);
+		if (log.isInfoEnabled()) log.info("host : {}", host);
+		if (log.isInfoEnabled()) log.info("port : {}", port);
+		if (log.isInfoEnabled()) log.info("ssl : {}", ssl);
+		if (ssl) if (log.isInfoEnabled()) log.info("sslTrustAll : {}", sslTrustAll);
+		if (log.isInfoEnabled()) log.info("database : {}", database);
+		if (log.isInfoEnabled()) log.info("collection : {}", collection_);
 	}
 
 	/**
@@ -125,12 +125,12 @@ public class MongoDBDealReportingImpl implements DealReporting.Impl {
 			JsonObject query = new JsonObject().put("dealId", dealId);
 			client_.findOneAndReplaceWithOptions(collection_, query, deal, FIND_OPTIONS_, UPDATE_OPTIONS_, res -> {
 				if (res.succeeded()) {
-//					if (log.isDebugEnabled()) log.debug("findOneAndReplaceWithOptions succeeded : " + res.result());
+//					if (log.isDebugEnabled()) log.debug("findOneAndReplaceWithOptions succeeded : {}", res.result());
 					completionHandler.handle(Future.succeededFuture());
 				} else {
-					log.error("Communication failed with MongoDB ; " + res.cause());
-					log.error("query : " + query);
-					log.error("deal : " + deal);
+					log.error("Communication failed with MongoDB ; {}", res.cause());
+					log.error("query : {}", query);
+					log.error("deal : {}", deal);
 					completionHandler.handle(Future.failedFuture(res.cause()));
 				}
 			});

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBDealReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBDealReportingImpl.java
@@ -128,7 +128,7 @@ public class MongoDBDealReportingImpl implements DealReporting.Impl {
 //					if (log.isDebugEnabled()) log.debug("findOneAndReplaceWithOptions succeeded : {}", res.result());
 					completionHandler.handle(Future.succeededFuture());
 				} else {
-					log.error("Communication failed with MongoDB ; {}", res.cause());
+					log.error("Communication failed with MongoDB", res.cause());
 					log.error("query : {}", query);
 					log.error("deal : {}", deal);
 					completionHandler.handle(Future.failedFuture(res.cause()));

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBUnitDataReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBUnitDataReportingImpl.java
@@ -116,7 +116,7 @@ public class MongoDBUnitDataReportingImpl implements UnitDataReporting.Impl {
 //				if (log.isDebugEnabled()) log.debug("insert succeeded : {}", res.result());
 				completionHandler.handle(Future.succeededFuture());
 			} else {
-				log.error("Communication failed with MongoDB ; {}", res.cause());
+				log.error("Communication failed with MongoDB", res.cause());
 				log.error("unitData : {}", data);
 				completionHandler.handle(Future.failedFuture(res.cause()));
 			}

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBUnitDataReportingImpl.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/ccc/impl/mongo_db/MongoDBUnitDataReportingImpl.java
@@ -9,8 +9,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.vertx.ext.mongo.MongoClient;
 import jp.co.sony.csl.dcoes.apis.common.util.DateTimeUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.JsonObjectUtil;
@@ -80,12 +80,12 @@ public class MongoDBUnitDataReportingImpl implements UnitDataReporting.Impl {
 		if (ssl) config.put("trustAll", sslTrustAll);
 		client_ = MongoClient.createShared(vertx, config);
 		collection_ = VertxConfig.config.getString("unitDataReporting", "collection");
-		if (log.isInfoEnabled()) log.info("host : " + host);
-		if (log.isInfoEnabled()) log.info("port : " + port);
-		if (log.isInfoEnabled()) log.info("ssl : " + ssl);
-		if (ssl) if (log.isInfoEnabled()) log.info("sslTrustAll : " + sslTrustAll);
-		if (log.isInfoEnabled()) log.info("database : " + database);
-		if (log.isInfoEnabled()) log.info("collection : " + collection_);
+		if (log.isInfoEnabled()) log.info("host : {}", host);
+		if (log.isInfoEnabled()) log.info("port : {}", port);
+		if (log.isInfoEnabled()) log.info("ssl : {}", ssl);
+		if (ssl) if (log.isInfoEnabled()) log.info("sslTrustAll : {}", sslTrustAll);
+		if (log.isInfoEnabled()) log.info("database : {}", database);
+		if (log.isInfoEnabled()) log.info("collection : {}", collection_);
 	}
 
 	/**
@@ -113,11 +113,11 @@ public class MongoDBUnitDataReportingImpl implements UnitDataReporting.Impl {
 		convertDateTimeField_(data);
 		client_.insert(collection_, data, res -> {
 			if (res.succeeded()) {
-//				if (log.isDebugEnabled()) log.debug("insert succeeded : " + res.result());
+//				if (log.isDebugEnabled()) log.debug("insert succeeded : {}", res.result());
 				completionHandler.handle(Future.succeededFuture());
 			} else {
-				log.error("Communication failed with MongoDB ; " + res.cause());
-				log.error("unitData : " + data);
+				log.error("Communication failed with MongoDB ; {}", res.cause());
+				log.error("unitData : {}", data);
 				completionHandler.handle(Future.failedFuture(res.cause()));
 			}
 		});


### PR DESCRIPTION
Upgrade apis-common from Vert.x 3 to Vert.x 4.5.10:

I tried to follow the same logic in [`Hyphae/apis-common#8`](https://github.com/hyphae/apis-common/pull/8), and [Migration Guide from Vert.x](https://vertx.io/docs/guides/vertx-4-migration-guide/)

This Repo includes:
- update Java 8 -> 11
- Change `start(Future)` to `start(Promise)`, updated in multiple locations
- created different `cluster.xml` for Hazelcast which upgraded from 3.12 to 5.3.
- in vert.x 4 the method `send()` removed and `request()` used.
- The HTTP POST handlers are deprecated, so I tried to implement new ones as in vert.x 4 (to be tested)
- Modernisation of the logging, Logger and LoggerFactory were deprecated, changed to `SLF4J`